### PR TITLE
github-ci: Add GitHub Actions CI Workflow for Oniro Apps Build, Signi…

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,96 @@
+name: Verify Build
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build:
+    name: Build and Verify Application
+    runs-on: macos-latest
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Install tree command
+        run: brew install tree
+
+      - name: Setup signing certificates and keystore
+        # This step extracts the required signing materials from a base64 encoded zip stored in GitHub Secrets
+        # The zip contains:
+        # - .cer file: Developer certificate for signing
+        # - .p7b file: Profile for app provisioning
+        # - .p12 file: Keystore containing private key
+        run: |
+          # Decode base64 secret to zip file
+          echo "${{ secrets.ONIRO_APP_SIGNATURE_ZIP }}" | base64 -d > secrets.zip
+          
+          # Extract files while preserving directory structure
+          unzip -o secrets.zip
+          
+          # Cleanup temporary zip file
+          rm secrets.zip
+          
+          # Display extracted files for verification
+          echo "=== Extracted Signing Materials ==="
+          tree .secret -L 4
+
+      - name: Modify bundleName in app.json5
+        run: |
+          echo "Modifying bundleName in app.json5 to match the one in the signature materials"
+          echo "this is a temporary workaround for using the same signature materials stored"
+          echo "in GitHub secrets for multiple apps."
+          echo "See: https://github.com/eclipse-oniro4openharmony/oniro-planning/issues/5#issuecomment-2538648996"
+          sed -i '' 's/"bundleName": "[^"]*"/"bundleName": "com.example.oniromathpunching"/' ./AppScope/app.json5
+
+      - name: Set up tools and dependencies
+        uses: eclipse-oniro4openharmony/oh-app-action@main
+        
+      - name: Verify Installation
+        run: |
+          echo "=== Environment Variables ==="
+          echo "PATH: $PATH"
+          echo "OHOS_BASE_SDK_HOME: $OHOS_BASE_SDK_HOME"
+          echo "CMD_PATH: $CMD_PATH"
+
+          echo "=== OHPM Installation ==="
+          which ohpm
+          ohpm -v
+
+          echo "=== Hvigor Installation ==="
+          which hvigorw
+          hvigorw --version
+
+          echo "=== Installation Directories ==="
+          echo "Command-line Tools:"
+          tree -L 3 $CMD_PATH
+
+          echo "OpenHarmony SDK:"
+          tree -L 3 $OHOS_BASE_SDK_HOME
+
+          echo "=== Node.js Version ==="
+          node --version
+          npm --version
+
+          echo "=== NPM Configuration ==="
+          cat $HOME/.npmrc
+
+      - name: Install OpenHarmony Dependencies
+        run: ohpm install --all
+
+      - name: Initialize and Build
+        run: |
+          hvigorw --version --accept-license
+          hvigorw clean --no-parallel --no-daemon
+          hvigorw assembleHap --mode module -p product=default --stacktrace --no-parallel --no-daemon
+
+      - name: Upload Build Artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: HAP packages
+          path: ./entry/build/default/outputs/default

--- a/build-profile.json5
+++ b/build-profile.json5
@@ -4,13 +4,13 @@
       {
         "name": "default",
         "material": {
-          "certpath": "C:\\Users\\P00925477\\.ohos\\config\\openharmony\\auto_ohos_default_MyWeather_com.example.myweather.cer",
-          "storePassword": "0000001B47B45EF2325207C200FA3EDC71341944EF7AB5DD45B40D4A49C09A0C532CD8F2AC7780ED7F8963",
+          "certpath": "./.secret/oniro-ci.cer",
+          "storePassword": "0000001BD5A16C997F0EF958596A946A060A50ED61DF4D945A74AB3C462CBCFBE5BA90427A3DEAC0D27D3E",
           "keyAlias": "debugKey",
-          "keyPassword": "0000001BCB0CB72A9D84BF10ECE7CEDB8D46BF124DE910DD196BF39B7CB469465D081A36FEBAC070FFA124",
-          "profile": "C:\\Users\\P00925477\\.ohos\\config\\openharmony\\auto_ohos_default_MyWeather_com.example.myweather.p7b",
+          "keyPassword": "0000001BACA49D623B16BE8A9C4C216A9ED64244F7255BC9AEF8C862264DDA900496AD36202857353771E8",
+          "profile": "./.secret/oniro-ci.p7b",
           "signAlg": "SHA256withECDSA",
-          "storeFile": "C:\\Users\\P00925477\\.ohos\\config\\openharmony\\auto_ohos_default_MyWeather_com.example.myweather.p12"
+          "storeFile": "./.secret/oniro-ci.p12"
         }
       }
     ],


### PR DESCRIPTION
…ng, and HAP Generation

This commit introduces a GitHub Actions workflow to verify builds for Oniro applications. The workflow performs the following tasks:
- Checks out the repository
- Sets up signing certificates and keystore from GitHub secrets
- Modifies `bundleName` in `app.json5` to match signing materials
- Installs necessary tools and dependencies for building Oniro apps
- Verifies environment setup and tools installation
- Builds the application and generates HAP packages
- Uploads build artifacts for further use

build-profile.json5: set signing materials to keys stored in GitHub secrets

This addresses [issue
#5](https://github.com/eclipse-oniro4openharmony/oniro-planning/issues/5)